### PR TITLE
Fixed Zybo preset for Eth0 MDIO pins

### DIFF
--- a/new/board_files/zybo/B.3/preset.xml
+++ b/new/board_files/zybo/B.3/preset.xml
@@ -7,6 +7,7 @@
         <user_parameter name="CONFIG.PCW_CRYSTAL_PERIPHERAL_FREQMHZ" value="50.000000"/> 
         <user_parameter name="CONFIG.PCW_ENET0_ENET0_IO" value="MIO 16 .. 27"/> 
         <user_parameter name="CONFIG.PCW_ENET0_GRP_MDIO_ENABLE" value="1"/> 
+        <user_parameter name="CONFIG.PCW_ENET0_GRP_MDIO_IO" value="MIO 52 .. 53"/> 
         <user_parameter name="CONFIG.PCW_ENET0_PERIPHERAL_ENABLE" value="1"/> 
         <user_parameter name="CONFIG.PCW_ENET0_RESET_ENABLE" value="0"/> 
         <user_parameter name="CONFIG.PCW_FPGA0_PERIPHERAL_FREQMHZ" value="100"/> 


### PR DESCRIPTION
On Zybo board ETH0 MDIO pins are connected not via EMIO, but via MIO[52..53].
![alt text](http://s3.amazonaws.com/igorfreire-personal-page/wp-content/uploads/2016/11/20181847/zybo_phy_signals.png "Zybo Ethernet PHY signals")