### PR TITLE
The part number syntax was updated for Arty-A7-100. Previously, with …

### DIFF
--- a/new/board_files/arty-a7-100/E.0/board.xml
+++ b/new/board_files/arty-a7-100/E.0/board.xml
@@ -6,7 +6,7 @@
 <file_version>1.0</file_version>
 <description>Arty A7-100</description>
 <components>
-  <component name="part0" display_name="Arty A7-100" type="fpga" part_name="xc7a100tcsg324-1" pin_map_file="part0_pins.xml" vendor="xilinx" spec_url="https://reference.digilentinc.com/reference/programmable-logic/arty-a7/start">
+  <component name="part0" display_name="Arty A7-100" type="fpga" part_name="xc7a100ticsg324-1L" pin_map_file="part0_pins.xml" vendor="xilinx" spec_url="https://reference.digilentinc.com/reference/programmable-logic/arty-a7/start">
     <interfaces>
       <interface mode="master" name="ddr3_sdram" type="xilinx.com:interface:ddrx_rtl:1.0" of_component="ddr3_sdram" preset_proc="ddr3_sdram_preset"> 
 		<description>DDR3 board interface, it can use MIG IP for connection.</description>

--- a/new/board_files/arty-a7-100/E.0/mig.prj
+++ b/new/board_files/arty-a7-100/E.0/mig.prj
@@ -8,7 +8,7 @@
     <DataDepth_En>1024</DataDepth_En>
     <LowPower_En>ON</LowPower_En>
     <XADC_En>Enabled</XADC_En>
-    <TargetFPGA>xc7a100t-csg324/-1</TargetFPGA>
+    <TargetFPGA>xc7a100ti-csg324/-1L</TargetFPGA>
     <Version>2.3</Version>
     <SystemClock>No Buffer</SystemClock>
     <ReferenceClock>No Buffer</ReferenceClock>


### PR DESCRIPTION
…Xilinx Vivado projects it was necessary to use the full part number with details, otherwise the DDR3 MIG controller would not automatically generate in IPI Block Design when dragging the DDR3 item from the Board list to the diagram.