### PR TITLE
Increment Genesys ZU-3EG revision B.0 file version

### DIFF
--- a/new/board_files/genesys-zu-3eg/D.0/board.xml
+++ b/new/board_files/genesys-zu-3eg/D.0/board.xml
@@ -3,7 +3,7 @@
 <compatible_board_revisions>
 	<revision id="0">D.0</revision>
 </compatible_board_revisions>
-<file_version>1.0</file_version>
+<file_version>1.1</file_version>
 <description>Genesys ZU-3EG</description>
 
 <components>


### PR DESCRIPTION
When the two different revisions of the ZU-3EG's board files had the same file version, only one of them would appear in the board selection screen in Vivado, preventing the D.0 version from appearing. Functionally, this also changes the following parameters in the Ultrascale PS preset (when the "Latest" revision of the board files is selected, as is default):

original (B.0):
```
<user_parameter name="CONFIG.PSU_DYNAMIC_DDR_CONFIG_EN" value="1"/>
<user_parameter name="CONFIG.PSU__DDRC__DDR4_ADDR_MAPPING" value="0"/>
```

after this commit (D.0):
```
<user_parameter name="CONFIG.PSU_DYNAMIC_DDR_CONFIG_EN" value="0"/>
<user_parameter name="CONFIG.PSU__DDRC__DDR4_ADDR_MAPPING" value="1"/>
```