### PR TITLE
@mohanex correcting uart pins on nexys video

### DIFF
--- a/new/board_files/nexys_video/A.0/1.1/part0_pins.xml
+++ b/new/board_files/nexys_video/A.0/1.1/part0_pins.xml
@@ -67,8 +67,8 @@ SOFTWARE.
   <pin index="40" name ="qspi_db2_i" iostandard="LVCMOS33" loc="P21"/>
   <pin index="41" name ="qspi_db3_i" iostandard="LVCMOS33" loc="R21"/>
   <pin index="42" name ="reset" iostandard="LVCMOS15" loc="G4"/>
-  <pin index="43" name ="usb_uart_rxd" iostandard="LVCMOS33" loc="V18"/>
-  <pin index="44" name ="usb_uart_txd" iostandard="LVCMOS33" loc="AA19"/>
+  <pin index="43" name ="usb_uart_rxd" iostandard="LVCMOS33" loc="AA19"/>
+  <pin index="44" name ="usb_uart_txd" iostandard="LVCMOS33" loc="V18"/>
   <pin index="45" name ="phy_reset_n" iostandard="LVCMOS33" loc="U7"/>
   <pin index="46" name ="hdmi_rx_hpd" iostandard="LVCMOS33" loc="AB12"/>
   <pin index="47" name ="TMDS_IN_clk_p" iostandard="TMDS_33" loc="V4"/>

--- a/new/board_files/nexys_video/A.0/1.2/part0_pins.xml
+++ b/new/board_files/nexys_video/A.0/1.2/part0_pins.xml
@@ -67,8 +67,8 @@ SOFTWARE.
   <pin index="40" name ="qspi_db2_i" iostandard="LVCMOS33" loc="P21"/>
   <pin index="41" name ="qspi_db3_i" iostandard="LVCMOS33" loc="R21"/>
   <pin index="42" name ="reset" iostandard="LVCMOS15" loc="G4"/>
-  <pin index="43" name ="usb_uart_rxd" iostandard="LVCMOS33" loc="V18"/>
-  <pin index="44" name ="usb_uart_txd" iostandard="LVCMOS33" loc="AA19"/>
+  <pin index="43" name ="usb_uart_rxd" iostandard="LVCMOS33" loc="AA19"/>
+  <pin index="44" name ="usb_uart_txd" iostandard="LVCMOS33" loc="V18"/>
   <pin index="45" name ="phy_reset_n" iostandard="LVCMOS33" loc="U7"/>
   <pin index="46" name ="hdmi_rx_hpd" iostandard="LVCMOS33" loc="AB12"/>
   <pin index="47" name ="TMDS_IN_clk_p" iostandard="TMDS_33" loc="V4"/>


### PR DESCRIPTION
I'm using Vivado 2020.2 and I added the contraints files to it using this git repository but when I started working on my Nexys Video, I had a constant issue with the UART pins not being assigned correctly, furthermore my Serial Monitoring doesn't receive anything.

I referred to the [digilent/digilent-xdc](https://github.com/Digilent/digilent-xdc/blob/master/Nexys-Video-Master.xdc) and found out that Rx and Tx pins are inversed so I corrected it.