### PR TITLE
Zybo: Corrected CPU PLL settings

### DIFF
--- a/new/board_files/zybo-z7-10/A.0/board.xml
+++ b/new/board_files/zybo-z7-10/A.0/board.xml
@@ -26,7 +26,7 @@ SOFTWARE.
 <compatible_board_revisions>
   <revision id="0">B.2</revision>
 </compatible_board_revisions>
-<file_version>1.1</file_version>
+<file_version>1.2</file_version>
 <description>Zybo Z7-10</description>
 <components>
   <component name="part0" display_name="Zybo Z7-10" type="fpga" part_name="xc7z010clg400-1" pin_map_file="part0_pins.xml" vendor="xilinx" spec_url="https://digilent.com/reference/programmable-logic/zybo-z7/start">

--- a/new/board_files/zybo-z7-10/A.0/preset.xml
+++ b/new/board_files/zybo-z7-10/A.0/preset.xml
@@ -28,9 +28,9 @@ SOFTWARE.
       <user_parameters>
 		<user_parameter name="CONFIG.PCW_DDR_RAM_HIGHADDR" value="0x3FFFFFFF"/> 
 		<user_parameter name="CONFIG.PCW_APU_CLK_RATIO_ENABLE" value="6:2:1"/>
-		<user_parameter name="CONFIG.PCW_APU_PERIPHERAL_FREQMHZ" value="667"/>
-		<user_parameter name="CONFIG.PCW_ARMPLL_CTRL_FBDIV" value="39"/>
-		<user_parameter name="CONFIG.PCW_CPU_CPU_PLL_FREQMHZ" value="1300.000"/>
+		<user_parameter name="CONFIG.PCW_APU_PERIPHERAL_FREQMHZ" value="666.666666"/>
+		<user_parameter name="CONFIG.PCW_ARMPLL_CTRL_FBDIV" value="40"/>
+		<user_parameter name="CONFIG.PCW_CPU_CPU_PLL_FREQMHZ" value="1333.333"/>
 		<user_parameter name="CONFIG.PCW_CPU_PERIPHERAL_CLKSRC" value="ARM PLL"/>
 		<user_parameter name="CONFIG.PCW_CPU_PERIPHERAL_DIVISOR0" value="2"/>
 		<user_parameter name="CONFIG.PCW_CRYSTAL_PERIPHERAL_FREQMHZ" value="33.333333"/>

--- a/new/board_files/zybo-z7-20/A.0/board.xml
+++ b/new/board_files/zybo-z7-20/A.0/board.xml
@@ -26,7 +26,7 @@ SOFTWARE.
 <compatible_board_revisions>
   <revision id="0">B.2</revision>
 </compatible_board_revisions>
-<file_version>1.1</file_version>
+<file_version>1.2</file_version>
 <description>Zybo Z7-20</description>
 <components>
   <component name="part0" display_name="Zybo Z7-20" type="fpga" part_name="xc7z020clg400-1" pin_map_file="part0_pins.xml" vendor="xilinx" spec_url="https://digilent.com/reference/programmable-logic/zybo-z7/start">

--- a/new/board_files/zybo-z7-20/A.0/preset.xml
+++ b/new/board_files/zybo-z7-20/A.0/preset.xml
@@ -28,9 +28,9 @@ SOFTWARE.
       <user_parameters>
 		<user_parameter name="CONFIG.PCW_DDR_RAM_HIGHADDR" value="0x3FFFFFFF"/> 
 		<user_parameter name="CONFIG.PCW_APU_CLK_RATIO_ENABLE" value="6:2:1"/>
-		<user_parameter name="CONFIG.PCW_APU_PERIPHERAL_FREQMHZ" value="667"/>
-		<user_parameter name="CONFIG.PCW_ARMPLL_CTRL_FBDIV" value="39"/>
-		<user_parameter name="CONFIG.PCW_CPU_CPU_PLL_FREQMHZ" value="1300.000"/>
+		<user_parameter name="CONFIG.PCW_APU_PERIPHERAL_FREQMHZ" value="666.666666"/>
+		<user_parameter name="CONFIG.PCW_ARMPLL_CTRL_FBDIV" value="40"/>
+		<user_parameter name="CONFIG.PCW_CPU_CPU_PLL_FREQMHZ" value="1333.333"/>
 		<user_parameter name="CONFIG.PCW_CPU_PERIPHERAL_CLKSRC" value="ARM PLL"/>
 		<user_parameter name="CONFIG.PCW_CPU_PERIPHERAL_DIVISOR0" value="2"/>
 		<user_parameter name="CONFIG.PCW_CRYSTAL_PERIPHERAL_FREQMHZ" value="33.333333"/>


### PR DESCRIPTION
Corrected CPU PLL settings for a CPU frequency of 666.666 MHz.
The old files use a wrong settings for this frequency.