### PR TITLE
Corrected + Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This repository contains the files used by Vivado IP Integrator to support Digil
 
 The `old` folder is for use with Vivado versions 2014.4 and below. The `new` folder covers Vivado 2015.x and above.
 
-Installation instructions for the `new` files can be found in [Section 3](https://digilent.com/reference/programmable-logic/guides/installing-vivado-and-vitis#install_digilent_s_board_files) of the *Installing Vivado, Vitis, and Digilent Board Files* guide on Digilent Refeernce.
+Installation instructions for the `new` files can be found in [Section 3](https://digilent.com/reference/programmable-logic/guides/installing-vivado-and-vitis#install_digilent_s_board_files) of the *Installing Vivado, Vitis, and Digilent Board Files* guide on Digilent Reference.
+After following adding the files as explained in the tutorial, make sure you add them to you Vivado, by going to `Tools > Settings > Vivado Store > Board Repository` and add the folder containing the boards. 
 
 Installation instructions for the `old` files can be found in the [Installing Vivado Board Files for Digilent Boards (Legacy)](https://digilent.com/reference/vivado/boardfiles) guide on the Digilent Wiki.
 


### PR DESCRIPTION
Adding a missing step in the guide for the addition of the boards repository to Vivado (latest version).
I encountered this issue today and one of the answers from [this reference](https://adaptivesupport.amd.com/s/question/0D52E00006hpRhYSAU/how-to-add-board-file-to-vivado-20211?language=en_US) solves the issue.