### PR TITLE
[ZYBO Z7-10] fix: MIO50/51 are physically connected to BTN4/5 with pull-down

### DIFF
--- a/new/board_files/zybo-z7-10/A.0/preset.xml
+++ b/new/board_files/zybo-z7-10/A.0/preset.xml
@@ -251,11 +251,11 @@ SOFTWARE.
 		<user_parameter name="CONFIG.PCW_MIO_4_SLEW" value="slow"/>
 		<user_parameter name="CONFIG.PCW_MIO_50_DIRECTION" value="inout"/>
 		<user_parameter name="CONFIG.PCW_MIO_50_IOTYPE" value="LVCMOS 1.8V"/>
-		<user_parameter name="CONFIG.PCW_MIO_50_PULLUP" value="enabled"/>
+		<user_parameter name="CONFIG.PCW_MIO_50_PULLUP" value="disabled"/>
 		<user_parameter name="CONFIG.PCW_MIO_50_SLEW" value="slow"/>
 		<user_parameter name="CONFIG.PCW_MIO_51_DIRECTION" value="inout"/>
 		<user_parameter name="CONFIG.PCW_MIO_51_IOTYPE" value="LVCMOS 1.8V"/>
-		<user_parameter name="CONFIG.PCW_MIO_51_PULLUP" value="enabled"/>
+		<user_parameter name="CONFIG.PCW_MIO_51_PULLUP" value="disabled"/>
 		<user_parameter name="CONFIG.PCW_MIO_51_SLEW" value="slow"/>
 		<user_parameter name="CONFIG.PCW_MIO_52_DIRECTION" value="out"/>
 		<user_parameter name="CONFIG.PCW_MIO_52_IOTYPE" value="LVCMOS 1.8V"/>


### PR DESCRIPTION
Fix #53 @elodg @artvvb